### PR TITLE
Auto ack on unknown deserializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     },
     "require-dev": {
         "phing/phing": "~2.11",
-        "phpunit/php-token-stream": "1.4.6",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^7.5",
         "satooshi/php-coveralls": "~0.7",
         "squizlabs/php_codesniffer": "2.6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "license": "Apache-2.0",
     "authors": [],
     "require": {
+        "2dotstwice/collection": "~1.1",
         "broadway/broadway": "~0.10",
-        "php-amqplib/php-amqplib": "2.6.*",
-        "cultuurnet/valueobjects": "~3.0",
-        "psr/log": "~1.0",
         "cultuurnet/deserializer": "~0.1",
-        "2dotstwice/collection": "~1.1"
+        "cultuurnet/valueobjects": "~3.0",
+        "php-amqplib/php-amqplib": "2.6.*",
+        "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
-        "phpunit/php-token-stream": "1.4.6",
-        "squizlabs/php_codesniffer": "2.6.1",
         "phing/phing": "~2.11",
-        "satooshi/php-coveralls": "~0.7"
+        "phpunit/php-token-stream": "1.4.6",
+        "phpunit/phpunit": "~5.7",
+        "satooshi/php-coveralls": "~0.7",
+        "squizlabs/php_codesniffer": "2.6.1"
     },
     "autoload": {
         "psr-4": {
@@ -35,5 +35,8 @@
         "branch-alias": {
             "dev-master": "0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     },
     "require-dev": {
         "phing/phing": "~2.11",
+        "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^7.5",
-        "satooshi/php-coveralls": "~0.7",
         "squizlabs/php_codesniffer": "2.6.1"
     },
     "autoload": {

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -153,6 +153,8 @@ abstract class AbstractConsumer implements ConsumerInterface
                     $context
                 );
             }
+
+            return;
         } catch (\Exception $e) {
             if ($this->logger) {
                 $this->logger->error(

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\BroadwayAMQP;
 
 use CultuurNet\Deserializer\DeserializerLocatorInterface;
+use CultuurNet\Deserializer\DeserializerNotFoundException;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
@@ -142,6 +143,16 @@ abstract class AbstractConsumer implements ConsumerInterface
             }
 
             $this->handle($deserializedMessage, $context);
+        } catch (DeserializerNotFoundException $e) {
+            $message->delivery_info['channel']->basic_ack(
+                $message->delivery_info['delivery_tag']
+            );
+            if ($this->logger) {
+                $this->logger->info(
+                    'auto acknowledged message because no deserializer was configured for it',
+                    $context
+                );
+            }
         } catch (\Exception $e) {
             if ($this->logger) {
                 $this->logger->error(

--- a/tests/AMQPPublisherDecoratorTest.php
+++ b/tests/AMQPPublisherDecoratorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class AMQPPublisherDecoratorTest extends TestCase
 {
     /**
-     * @var AMQPPublisherInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var AMQPPublisherInterface|\PHPUnit\Framework\MockObject\
      */
     private $amqpPublisher;
 

--- a/tests/AMQPPublisherDecoratorTest.php
+++ b/tests/AMQPPublisherDecoratorTest.php
@@ -7,8 +7,9 @@ use Broadway\Domain\Metadata;
 use Broadway\Domain\DateTime as BroadwayDateTime;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use Broadway\EventHandling\EventListenerInterface as AMQPPublisherInterface;
+use PHPUnit\Framework\TestCase;
 
-class AMQPPublisherDecoratorTest extends \PHPUnit_Framework_TestCase
+class AMQPPublisherDecoratorTest extends TestCase
 {
     /**
      * @var AMQPPublisherInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/AMQPPublisherTest.php
+++ b/tests/AMQPPublisherTest.php
@@ -13,13 +13,14 @@ use CultuurNet\BroadwayAMQP\Message\DelegatingAMQPMessageFactory;
 use CultuurNet\BroadwayAMQP\Message\Properties\CorrelationIdPropertiesFactory;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
  * Class AMQPPublisherTest
  * @package CultuurNet\BroadwayAMQP
  */
-class AMQPPublisherTest extends \PHPUnit_Framework_TestCase
+class AMQPPublisherTest extends TestCase
 {
     /**
      * @var AMQPChannel|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/AMQPPublisherTest.php
+++ b/tests/AMQPPublisherTest.php
@@ -13,6 +13,7 @@ use CultuurNet\BroadwayAMQP\Message\DelegatingAMQPMessageFactory;
 use CultuurNet\BroadwayAMQP\Message\Properties\CorrelationIdPropertiesFactory;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -23,12 +24,12 @@ use Psr\Log\LoggerInterface;
 class AMQPPublisherTest extends TestCase
 {
     /**
-     * @var AMQPChannel|\PHPUnit_Framework_MockObject_MockObject
+     * @var AMQPChannel|MockObject
      */
     private $amqpChannel;
 
     /**
-     * @var SpecificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SpecificationInterface|MockObject
      */
     private $specification;
 
@@ -142,7 +143,7 @@ class AMQPPublisherTest extends TestCase
     {
         $this->expectSpecificationIsSatisfied();
 
-        /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
+        /** @var LoggerInterface|MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $this->amqpPublisher->setLogger($logger);
 
@@ -163,7 +164,7 @@ class AMQPPublisherTest extends TestCase
     {
         $this->expectSpecificationIsNotSatisfied();
 
-        /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
+        /** @var LoggerInterface|MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $this->amqpPublisher->setLogger($logger);
 

--- a/tests/CommandBusForwardingConsumerTest.php
+++ b/tests/CommandBusForwardingConsumerTest.php
@@ -9,10 +9,11 @@ use PhpAmqpLib\Channel\AbstractChannel;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class CommandBusForwardingConsumerTest extends \PHPUnit_Framework_TestCase
+class CommandBusForwardingConsumerTest extends TestCase
 {
     /**
      * @var AMQPStreamConnection|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/CommandBusForwardingConsumerTest.php
+++ b/tests/CommandBusForwardingConsumerTest.php
@@ -9,6 +9,7 @@ use PhpAmqpLib\Channel\AbstractChannel;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -16,7 +17,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class CommandBusForwardingConsumerTest extends TestCase
 {
     /**
-     * @var AMQPStreamConnection|\PHPUnit_Framework_MockObject_MockObject
+     * @var AMQPStreamConnection|MockObject
      */
     private $connection;
 
@@ -36,17 +37,17 @@ class CommandBusForwardingConsumerTest extends TestCase
     private $consumerTag;
 
     /**
-     * @var CommandBusInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBusInterface|MockObject
      */
     private $commandBus;
 
     /**
-     * @var DeserializerLocatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerLocatorInterface|MockObject
      */
     private $deserializerLocator;
 
     /**
-     * @var AbstractChannel|\PHPUnit_Framework_MockObject_MockObject
+     * @var AbstractChannel|MockObject
      */
     private $channel;
 
@@ -63,12 +64,12 @@ class CommandBusForwardingConsumerTest extends TestCase
     private $commandBusForwardingConsumer;
 
     /**
-     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var LoggerInterface|MockObject
      */
     private $logger;
 
     /**
-     * @var DeserializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerInterface|MockObject
      */
     private $deserializer;
 
@@ -103,7 +104,7 @@ class CommandBusForwardingConsumerTest extends TestCase
             $this->delay
         );
 
-        /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
+        /** @var LoggerInterface|MockObject $logger */
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->commandBusForwardingConsumer->setLogger($this->logger);
 

--- a/tests/DomainMessage/AnyOfTest.php
+++ b/tests/DomainMessage/AnyOfTest.php
@@ -7,8 +7,9 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
+use PHPUnit\Framework\TestCase;
 
-class AnyOfTest extends \PHPUnit_Framework_TestCase
+class AnyOfTest extends TestCase
 {
     /**
      * @var AnyOf

--- a/tests/DomainMessage/PayloadInNamespaceTest.php
+++ b/tests/DomainMessage/PayloadInNamespaceTest.php
@@ -6,8 +6,9 @@ use Broadway\Domain\DateTime as BroadwayDateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
+use PHPUnit\Framework\TestCase;
 
-class PayloadInNamespaceTest extends \PHPUnit_Framework_TestCase
+class PayloadInNamespaceTest extends TestCase
 {
     /**
      * @var DomainMessage

--- a/tests/DomainMessage/PayloadIsInstanceOfTest.php
+++ b/tests/DomainMessage/PayloadIsInstanceOfTest.php
@@ -8,8 +8,9 @@ use Broadway\Domain\Metadata;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventSubclass;
+use PHPUnit\Framework\TestCase;
 
-class PayloadIsInstanceOfTest extends \PHPUnit_Framework_TestCase
+class PayloadIsInstanceOfTest extends TestCase
 {
     /**
      * @var DomainMessage

--- a/tests/DomainMessage/SpecificationCollectionTest.php
+++ b/tests/DomainMessage/SpecificationCollectionTest.php
@@ -2,7 +2,9 @@
 
 namespace CultuurNet\BroadwayAMQP\DomainMessage;
 
-class SpecificationCollectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SpecificationCollectionTest extends TestCase
 {
     /**
      * @test

--- a/tests/DomainMessageJSONDeserializerTest.php
+++ b/tests/DomainMessageJSONDeserializerTest.php
@@ -7,9 +7,10 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
+use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class DomainMessageJSONDeserializerTest extends \PHPUnit_Framework_TestCase
+class DomainMessageJSONDeserializerTest extends TestCase
 {
     /**
      * @var DomainMessageJSONDeserializer

--- a/tests/EventBusForwardingConsumerTest.php
+++ b/tests/EventBusForwardingConsumerTest.php
@@ -11,10 +11,11 @@ use PhpAmqpLib\Channel\AbstractChannel;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
-class EventBusForwardingConsumerTest extends \PHPUnit_Framework_TestCase
+class EventBusForwardingConsumerTest extends TestCase
 {
     /**
      * @var AMQPStreamConnection|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/EventBusForwardingConsumerTest.php
+++ b/tests/EventBusForwardingConsumerTest.php
@@ -11,6 +11,7 @@ use PhpAmqpLib\Channel\AbstractChannel;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -18,7 +19,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class EventBusForwardingConsumerTest extends TestCase
 {
     /**
-     * @var AMQPStreamConnection|\PHPUnit_Framework_MockObject_MockObject
+     * @var AMQPStreamConnection|MockObject
      */
     private $connection;
 
@@ -38,17 +39,17 @@ class EventBusForwardingConsumerTest extends TestCase
     private $consumerTag;
 
     /**
-     * @var EventBusInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var EventBusInterface|MockObject
      */
     private $eventBus;
 
     /**
-     * @var DeserializerLocatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerLocatorInterface|MockObject
      */
     private $deserializerLocator;
 
     /**
-     * @var AbstractChannel|\PHPUnit_Framework_MockObject_MockObject
+     * @var AbstractChannel|MockObject
      */
     private $channel;
 
@@ -65,12 +66,12 @@ class EventBusForwardingConsumerTest extends TestCase
     private $eventBusForwardingConsumer;
 
     /**
-     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var LoggerInterface|MockObject
      */
     private $logger;
 
     /**
-     * @var DeserializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerInterface|MockObject
      */
     private $deserializer;
 
@@ -105,7 +106,7 @@ class EventBusForwardingConsumerTest extends TestCase
             $this->delay
         );
 
-        /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
+        /** @var LoggerInterface|MockObject $logger */
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->eventBusForwardingConsumer->setLogger($this->logger);
 

--- a/tests/Message/Body/EntireDomainMessageBodyFactoryTest.php
+++ b/tests/Message/Body/EntireDomainMessageBodyFactoryTest.php
@@ -8,8 +8,9 @@ use Broadway\Domain\Metadata;
 use Broadway\Serializer\SerializationException;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
+use PHPUnit\Framework\TestCase;
 
-class EntireDomainMessageBodyFactoryTest extends \PHPUnit_Framework_TestCase
+class EntireDomainMessageBodyFactoryTest extends TestCase
 {
     /**
      * @var EntireDomainMessageBodyFactory

--- a/tests/Message/Body/PayloadOnlyBodyFactoryTest.php
+++ b/tests/Message/Body/PayloadOnlyBodyFactoryTest.php
@@ -8,8 +8,9 @@ use Broadway\Domain\Metadata;
 use Broadway\Serializer\SerializationException;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
+use PHPUnit\Framework\TestCase;
 
-class PayloadOnlyBodyFactoryTest extends \PHPUnit_Framework_TestCase
+class PayloadOnlyBodyFactoryTest extends TestCase
 {
     /**
      * @var PayloadOnlyBodyFactory

--- a/tests/Message/DelegatingAMQPMessageFactoryTest.php
+++ b/tests/Message/DelegatingAMQPMessageFactoryTest.php
@@ -9,17 +9,18 @@ use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Message\Body\BodyFactoryInterface;
 use CultuurNet\BroadwayAMQP\Message\Properties\PropertiesFactoryInterface;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DelegatingAMQPMessageFactoryTest extends TestCase
 {
     /**
-     * @var BodyFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var BodyFactoryInterface|MockObject
      */
     private $bodyFactory;
 
     /**
-     * @var PropertiesFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PropertiesFactoryInterface|MockObject
      */
     private $propertiesFactory;
 

--- a/tests/Message/DelegatingAMQPMessageFactoryTest.php
+++ b/tests/Message/DelegatingAMQPMessageFactoryTest.php
@@ -9,8 +9,9 @@ use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Message\Body\BodyFactoryInterface;
 use CultuurNet\BroadwayAMQP\Message\Properties\PropertiesFactoryInterface;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
-class DelegatingAMQPMessageFactoryTest extends \PHPUnit_Framework_TestCase
+class DelegatingAMQPMessageFactoryTest extends TestCase
 {
     /**
      * @var BodyFactoryInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Message/Properties/CompositePropertiesFactoryTest.php
+++ b/tests/Message/Properties/CompositePropertiesFactoryTest.php
@@ -5,17 +5,18 @@ namespace CultuurNet\BroadwayAMQP\Message\Properties;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CompositePropertiesFactoryTest extends TestCase
 {
     /**
-     * @var PropertiesFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PropertiesFactoryInterface|MockObject
      */
     private $mockFactory1;
 
     /**
-     * @var PropertiesFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PropertiesFactoryInterface|MockObject
      */
     private $mockFactory2;
 

--- a/tests/Message/Properties/CompositePropertiesFactoryTest.php
+++ b/tests/Message/Properties/CompositePropertiesFactoryTest.php
@@ -5,8 +5,9 @@ namespace CultuurNet\BroadwayAMQP\Message\Properties;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use PHPUnit\Framework\TestCase;
 
-class CompositePropertiesFactoryTest extends \PHPUnit_Framework_TestCase
+class CompositePropertiesFactoryTest extends TestCase
 {
     /**
      * @var PropertiesFactoryInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Message/Properties/ContentTypeLookupTest.php
+++ b/tests/Message/Properties/ContentTypeLookupTest.php
@@ -3,8 +3,9 @@
 namespace CultuurNet\BroadwayAMQP\Message\Properties;
 
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
+use PHPUnit\Framework\TestCase;
 
-class ContentTypeLookupTest extends \PHPUnit_Framework_TestCase
+class ContentTypeLookupTest extends TestCase
 {
     /**
      * @var ContentTypeLookup

--- a/tests/Message/Properties/ContentTypePropertiesFactoryTest.php
+++ b/tests/Message/Properties/ContentTypePropertiesFactoryTest.php
@@ -7,8 +7,9 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventNotSerializable;
+use PHPUnit\Framework\TestCase;
 
-class ContentTypePropertiesFactoryTest extends \PHPUnit_Framework_TestCase
+class ContentTypePropertiesFactoryTest extends TestCase
 {
     /**
      * @var ContentTypeLookup

--- a/tests/Message/Properties/CorrelationIdPropertiesFactoryTest.php
+++ b/tests/Message/Properties/CorrelationIdPropertiesFactoryTest.php
@@ -5,8 +5,9 @@ namespace CultuurNet\BroadwayAMQP\Message\Properties;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use PHPUnit\Framework\TestCase;
 
-class CorrelationIdPropertiesFactoryTest extends \PHPUnit_Framework_TestCase
+class CorrelationIdPropertiesFactoryTest extends TestCase
 {
     /**
      * @var CorrelationIdPropertiesFactory

--- a/tests/Message/Properties/DeliveryModePropertiesFactoryTest.php
+++ b/tests/Message/Properties/DeliveryModePropertiesFactoryTest.php
@@ -6,8 +6,9 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
-class DeliveryModePropertiesFactoryTest extends \PHPUnit_Framework_TestCase
+class DeliveryModePropertiesFactoryTest extends TestCase
 {
     /**
      * @test

--- a/tests/Normalizer/CombinedDomainMessageNormalizerTest.php
+++ b/tests/Normalizer/CombinedDomainMessageNormalizerTest.php
@@ -8,22 +8,23 @@ use Broadway\Domain\Metadata;
 use Broadway\Domain\DateTime as BroadwayDateTime;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventSubclass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CombinedDomainMessageNormalizerTest extends TestCase
 {
     /**
-     * @var CombinedDomainMessageNormalizer|\PHPUnit_Framework_MockObject_MockObject
+     * @var CombinedDomainMessageNormalizer|MockObject
      */
     private $combinedDomainMessageNormalizer;
 
     /**
-     * @var DomainMessageNormalizerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DomainMessageNormalizerInterface|MockObject
      */
     private $dummyNormalizer;
 
     /**
-     * @var DomainMessageNormalizerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DomainMessageNormalizerInterface|MockObject
      */
     private $dummyChildNormalizer;
 

--- a/tests/Normalizer/CombinedDomainMessageNormalizerTest.php
+++ b/tests/Normalizer/CombinedDomainMessageNormalizerTest.php
@@ -8,8 +8,9 @@ use Broadway\Domain\Metadata;
 use Broadway\Domain\DateTime as BroadwayDateTime;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEventSubclass;
+use PHPUnit\Framework\TestCase;
 
-class CombinedDomainMessageNormalizerTest extends \PHPUnit_Framework_TestCase
+class CombinedDomainMessageNormalizerTest extends TestCase
 {
     /**
      * @var CombinedDomainMessageNormalizer|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Normalizer/DomainMessageNormalizerAMQPPublisherDecoratorTest.php
+++ b/tests/Normalizer/DomainMessageNormalizerAMQPPublisherDecoratorTest.php
@@ -8,12 +8,13 @@ use Broadway\Domain\Metadata;
 use Broadway\Domain\DateTime as BroadwayDateTime;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use Broadway\EventHandling\EventListenerInterface as AMQPPublisherInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DomainMessageNormalizerDecoratorTest
  * @package CultuurNet\BroadwayAMQP\Normalizer
  */
-class DomainMessageNormalizerAMQPPublisherDecoratorTest extends \PHPUnit_Framework_TestCase
+class DomainMessageNormalizerAMQPPublisherDecoratorTest extends TestCase
 {
     /**
      * @var DomainMessageNormalizerAMQPPublisherDecorator|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Normalizer/DomainMessageNormalizerAMQPPublisherDecoratorTest.php
+++ b/tests/Normalizer/DomainMessageNormalizerAMQPPublisherDecoratorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\Metadata;
 use Broadway\Domain\DateTime as BroadwayDateTime;
 use CultuurNet\BroadwayAMQP\Dummies\DummyEvent;
 use Broadway\EventHandling\EventListenerInterface as AMQPPublisherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,17 +18,17 @@ use PHPUnit\Framework\TestCase;
 class DomainMessageNormalizerAMQPPublisherDecoratorTest extends TestCase
 {
     /**
-     * @var DomainMessageNormalizerAMQPPublisherDecorator|\PHPUnit_Framework_MockObject_MockObject
+     * @var DomainMessageNormalizerAMQPPublisherDecorator|MockObject
      */
     private $domainMessageNormalizerAMQPPublisherDecorator;
     
     /**
-     * @var AMQPPublisherInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var AMQPPublisherInterface|MockObject
      */
     private $amqpPublisher;
     
     /**
-     * @var DomainMessageNormalizerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DomainMessageNormalizerInterface|MockObject
      */
     private $domainMessageNormalizer;
 


### PR DESCRIPTION
### Changed
- `AbstractConsumer` now automatically acknowledges a message when no deserializer was found
- Composer dependencies are now automatically sorted
- All tests now use the forward-compatible namespaced `TestCase` class
- Upgraded `phpunit/phpunit` to `^7.5`
- Upgraded `satosh/php-coverals ~0.7` to `php-coverals/php-coverals ^2.1`